### PR TITLE
Adding cases feature

### DIFF
--- a/x-pack/plugins/observability/kibana.json
+++ b/x-pack/plugins/observability/kibana.json
@@ -17,7 +17,8 @@
     "alerting",
     "ruleRegistry",
     "triggersActionsUi",
-    "cases"
+    "cases",
+    "features"
   ],
   "ui": true,
   "server": true,

--- a/x-pack/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/test/api_integration/apis/features/features/features.ts
@@ -114,6 +114,7 @@ export default function ({ getService }: FtrProviderContext) {
             'infrastructure',
             'logs',
             'maps',
+            'observabilityCases',
             'uptime',
             'siem',
             'fleet',

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -60,6 +60,7 @@ export default function ({ getService }: FtrProviderContext) {
             canvas: ['all', 'read', 'minimal_all', 'minimal_read', 'generate_report'],
             infrastructure: ['all', 'read'],
             logs: ['all', 'read'],
+            observabilityCases: ['all', 'read'],
             uptime: ['all', 'read'],
             apm: ['all', 'read'],
             ml: ['all', 'read'],


### PR DESCRIPTION
Adding the cases privilege feature

Cases shows up in the roles now

![image](https://user-images.githubusercontent.com/56361221/118722937-c208dd80-b7fa-11eb-9183-13a5677cd2dc.png)

If you're superuser you can post a case using `owner: 'observability'`

```
curl --location --request POST 'http://localhost:5601/api/cases' \
--header 'kbn-xsrf: hello' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'Content-Type: application/json' \
--data-raw '{
    "title": "blah case",
    "tags": [
        "super"
    ],
    "description": "awesome",
    "type": "individual",
    "connector": {
        "id": "none",
        "name": "none",
        "type": ".none",
        "fields": null
    },
    "settings": {
        "syncAlerts": true
    },
    "owner": "observability"
}'
```