### PR TITLE
[Steph] GroupingQuery type error fixed

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/grouping/query/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/query/index.ts
@@ -7,11 +7,10 @@
 
 import { isEmpty } from 'lodash/fp';
 import type {
-  CardinalitySubAggregation,
   GroupingQueryArgs,
   GroupingQuery,
-  OptionalSubAggregation,
-  TermsSubAggregation,
+  SubAggregation,
+  TermsOrCardinalityAggregation,
 } from './types';
 /** The maximum number of items to render */
 export const DEFAULT_STACK_BY_FIELD0_SIZE = 10;
@@ -28,8 +27,8 @@ const getOptionalSubAggregation = ({
   stackByMultipleFields1Size: number;
   stackByMultipleFields1From?: number;
   stackByMultipleFields1Sort?: Array<{ [category: string]: { order: 'asc' | 'desc' } }>;
-  additionalStatsAggregationsFields1: Array<CardinalitySubAggregation | TermsSubAggregation>;
-}): OptionalSubAggregation | {} =>
+  additionalStatsAggregationsFields1: TermsOrCardinalityAggregation[];
+}): SubAggregation | {} =>
   stackByMultipleFields1 != null && !isEmpty(stackByMultipleFields1)
     ? {
         stackByMultipleFields1: {
@@ -93,7 +92,6 @@ export const getGroupingQuery = ({
               size: MAX_QUERY_SIZE,
             },
           }),
-      // TODO: Fix this type error!
       aggs: {
         ...getOptionalSubAggregation({
           stackByMultipleFields1,


### PR DESCRIPTION
It is pretty complex to restrict an object with arbitrary keys and typed values, to have specific keys and specific values, TS wants the arbitrary key type to be compatible with the specific key type:

```
interface Example {
  specific: ThisType;
  [arbitrary: string]: HasToBeCompatibleWithThisOne;
}
```

Also, IMHO, there's no good reason in trying to create a very strict `GroupingQuery` type, the generation of this object is encapsulated in one function which is a black box from the outside. I changed this type to be more generic, just making sure it is a `estypes.QueryDslQueryContainer` type that ES can swallow, only adding some required fields.

What I think is good and we should keep doing is being strict with the `getGroupingQuery` function parameters, restricting all aggregations parameters to be terms or cardinality aggs only 👍 

What do you think?